### PR TITLE
Support using as development server for all elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,9 @@
     "vaadin-upload": "vaadin/vaadin-upload#1.0.0-beta1"
   },
   "devDependencies": {
+    "web-component-tester": "^4.0.3",
+    "test-fixture": "polymerelements/test-fixture#^1.0.0",
+    "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
     "iron-component-page": "polymerelements/iron-component-page#~1.1.0",
     "elements-demo-resources": "vaadin/elements-demo-resources#master",
     "components-demo-resources": "vaadin/components-demo-resources#master",

--- a/index.html
+++ b/index.html
@@ -1,0 +1,86 @@
+<!--
+@license
+Copyright (c) 2016 Vaadin Ltd.
+This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+-->
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title>Vaadin Core Elements</title>
+
+  <style>
+    body {
+      font: normal normal normal 12pt/1.5 sans-serif;
+      max-width: 48rem;
+      margin: 0 auto;
+      padding: 2rem;
+      }
+
+    nav {
+      text-align: left;
+      }
+
+      nav ul {
+        margin: 0 -1rem;
+        padding: 0;
+        list-style: none;
+        }
+
+      nav li {
+        display: inline-block;
+        vertical-align: top;
+        width: 8rem;
+        padding: 1rem;
+        text-align: center;
+        }
+
+    nav a {
+      display: block;
+      padding: 1rem;
+      background: deepskyblue;
+      color: white;
+      text-decoration: none;
+      -webkit-font-smoothing: antialiased;
+      transition: opacity .5s;
+      }
+
+    nav a:hover {
+      opacity: 0.75;
+      transition: opacity .1s;
+      }
+
+    nav a:first-child {
+      background: gray;
+      padding-top: .75rem;
+      padding-bottom: .75rem;
+      }
+
+
+  </style>
+</head>
+<body>
+  <h1>Vaadin Core Elements</h1>
+  <nav>
+    <ul class="layout horizontal wrap">
+      <li>
+        <a href="../vaadin-grid/">Vaadin<br> Grid</a>
+        <a href="../vaadin-grid/demo/">Demo</a>
+      <li>
+        <a href="../vaadin-combo-box/">Vaadin<br> ComboBox</a>
+        <a href="../vaadin-combo-box/demo/">Demo</a>
+      <li>
+        <a href="../vaadin-date-picker/">Vaadin<br> DatePicker</a>
+        <a href="../vaadin-date-picker/demo/">Demo</a>
+      <li>
+        <a href="../vaadin-upload/">Vaadin<br> Upload</a>
+        <a href="../vaadin-upload/demo/">Demo</a>
+      <li>
+        <a href="../vaadin-icons/">Vaadin<br> Icons</a>
+        <a href="../vaadin-icons/demo/">Demo</a>
+    </ul>
+  </nav>
+</body>
+</html>


### PR DESCRIPTION
As the number of Vaadin Core Elements increases, it becomes harder to switch between separate development servers for each individual elements.

For this reason this PR adds a few little changes to Core Elements repository to support running single polyserve development server for all elements on a local machine.

## Usage

### Setup

1. Create global bower links for each element's working directory:  

  ```
  $ cd ../vaadin-<element>
  $ bower link
  ```

2. Create links from bower_components to element repositories:  

  ```
  $ cd ../vaadin-core-elements
  $ bower link vaadin-grid
  $ bower link vaadin-combo-box
  $ bower link vaadin-date-picker
  $ bower link vaadin-upload
  $ bower link vaadin-icons
  ```  

3. Install remaining bower dependencies, and Polyserve:  

  ```
  $ bower install
  $ npm install -g polyserve
  ```

Now in bower_components directory there should be all the requirements alongside with Vaadin Core Elements linked to your working directories.

### Starting

Start `$ polyserve` in vaadin-core-elements directory, as usual. Open the given link in the browser and navigate to any component on a single server! Isn't it great?

## Known issues

None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-core-elements/44)
<!-- Reviewable:end -->