### PR TITLE
Improve cdn deployment of master versions

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "node": true,
+  "esnext": true
+}

--- a/bower.json
+++ b/bower.json
@@ -41,5 +41,16 @@
   },
   "resolutions": {
     "polymer": "v1.1.1"
+  },
+  "masterOverrides": {
+    "version": "master",
+    "dependencies": {
+      "vaadin-grid": "vaadin/vaadin-grid#master",
+      "vaadin-combo-box": "vaadin/vaadin-combo-box#master",
+      "vaadin-icons": "vaadin/vaadin-icons#master",
+      "vaadin-date-picker": "vaadin/vaadin-date-picker#master",
+      "vaadin-upload": "vaadin/vaadin-upload#master",
+      "vaadin-split-layout": "vaadin/vaadin-split-layout#master"
+    }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,11 +24,11 @@
     "**/tests"
   ],
   "dependencies": {
-    "vaadin-grid": "vaadin/vaadin-grid#~1.1.0",
-    "vaadin-combo-box": "vaadin/vaadin-combo-box#~1.1.0",
-    "vaadin-icons": "vaadin/vaadin-icons#~1.0.0",
-    "vaadin-date-picker": "vaadin/vaadin-date-picker#~1.1.0",
-    "vaadin-upload": "vaadin/vaadin-upload#~1.0.0"
+    "vaadin-grid": "vaadin/vaadin-grid#1.1.x",
+    "vaadin-combo-box": "vaadin/vaadin-combo-box#1.1.x",
+    "vaadin-icons": "vaadin/vaadin-icons#1.0.x",
+    "vaadin-date-picker": "vaadin/vaadin-date-picker#1.1.x",
+    "vaadin-upload": "vaadin/vaadin-upload#1.0.x"
   },
   "devDependencies": {
     "web-component-tester": "^4.0.3",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "authors": [
     "Vaadin Ltd"
   ],
-  "description": "Vaadin Core Elements is an evolving set of free, open sourced custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
+  "description": "Vaadin Core Elements is an evolving set of free, open sourced custom HTML elements, built using Polymer.",
   "license": "Apache-2.0",
   "keywords": [
     "vaadin",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,6 @@ gulp.task('default', function() {
   console.log('\n  Use:\n gulp <stage|deploy[:cdn]>|<zip>\n');
 });
 
-gulp.task('clean', ['clean:cdn', 'clean:zip']);
+gulp.task('clean', ['clean:cdn', 'clean:bower', 'clean:zip']);
 
 gulp.task('deploy', ['deploy:cdn']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,6 @@ gulp.task('default', function() {
   console.log('\n  Use:\n gulp <stage|deploy[:cdn]>|<zip>\n');
 });
 
-gulp.task('clean', ['clean:cdn', 'clean:bower', 'clean:zip']);
+gulp.task('clean', ['clean:cdn', 'clean:zip']);
 
 gulp.task('deploy', ['deploy:cdn']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,8 +4,6 @@ require('require-dir')('./tasks');
 var args = require('yargs').argv;
 var git = require('gulp-git');
 
-var version = '0.3.0';
-
 gulp.task('default', function() {
   console.log('\n  Use:\n gulp <stage|deploy[:cdn]>|<zip>\n');
 });

--- a/tasks/config.js
+++ b/tasks/config.js
@@ -4,7 +4,6 @@ var fs = require('fs');
 var userhome = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
 
 module.exports = {
-  coreElements: ['vaadin-grid', 'vaadin-combo-box', 'vaadin-date-picker', 'vaadin-upload', 'vaadin-icons'],
   version: args.version || 'master',
   permalink: args.version ? 'latest' : '',
   toolsHost: args.toolsHostname || 'tools.vaadin.com',

--- a/tasks/docsite.js
+++ b/tasks/docsite.js
@@ -19,6 +19,7 @@ var stagingPath = stagingBasePath + '/' + version;
 var modify = require('gulp-modify');
 var rootZip = 'target/';
 var fileZip = 'docsite.zip';
+var bowerJson = require('../bower.json');
 
 gulp.task('cdn:docsite:clean', function() {
   fs.removeSync(docPath);
@@ -56,9 +57,9 @@ gulp.task('cdn:docsite:core-elements-integrations', function() {
 });
 
 gulp.task('cdn:docsite:core-elements-elements', ['cdn:docsite:bower_components'], function() {
-  var docsPaths = config.coreElements.map(function(c) {
-      return stagingPath + '/' + c + '/docs/**';
-    });
+  var docsPaths = Object.keys(bowerJson.dependencies).map(function(c) {
+    return stagingPath + '/' + c + '/docs/**';
+  });
 
   return gulp.src(docsPaths, {base: stagingPath})
       .pipe(rename(function (path) {

--- a/tasks/docsite.js
+++ b/tasks/docsite.js
@@ -19,7 +19,6 @@ var stagingPath = stagingBasePath + '/' + version;
 var modify = require('gulp-modify');
 var rootZip = 'target/';
 var fileZip = 'docsite.zip';
-var bowerJson = require('../bower.json');
 
 gulp.task('cdn:docsite:clean', function() {
   fs.removeSync(docPath);
@@ -57,6 +56,7 @@ gulp.task('cdn:docsite:core-elements-integrations', function() {
 });
 
 gulp.task('cdn:docsite:core-elements-elements', ['cdn:docsite:bower_components'], function() {
+  const bowerJson = require('../' + stagingPath + '/bower.json');
   var docsPaths = Object.keys(bowerJson.dependencies).map(function(c) {
     return stagingPath + '/' + c + '/docs/**';
   });


### PR DESCRIPTION
Connects to vaadin/components-team-tasks#194

This PR will introduce generation of a separate `target/bower/bower.json` file with listed `config.masterElements` being deployed from their `master` branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-core-elements/67)
<!-- Reviewable:end -->
