### PR TITLE
Fix link ref

### DIFF
--- a/docs/elements-getting-started.adoc
+++ b/docs/elements-getting-started.adoc
@@ -150,7 +150,7 @@ After you have created the file and you have a local server serving the files, y
 
 +++
 <!-- Assumes .w-arrow-button and .blue class names from vaadin.com theme. Will fallback to a plain link. -->
-<a href="vaadin-grid/overview.html" class="w-arrow-button blue" style="display: inline-block">
+<a href="vaadin-grid/vaadin-grid-overview.html" class="w-arrow-button blue" style="display: inline-block">
   Vaadin Grid<br />
   <small>Continue to Vaadin Grid documentation</small>
 </a>


### PR DESCRIPTION
Current link is resolved as https://vaadin.com/docs/-/part/elements/vaadin-grid/overview.html which doesn't exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-core-elements/84)
<!-- Reviewable:end -->
