### PR TITLE
No need to mention bower install

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,21 +14,11 @@ The following instructions are common for all Vaadin core elements. **Replace `v
   $ git clone https://github.com/vaadin/vaadin-combo-box.git
   ```
 
-2. Install [Node](https://nodejs.org/en/download/). It comes bundled with [npm](https://npmjs.com), which is needed to install other tooling.
-
-3. Install [Bower](http://bower.io) using [npm](https://npmjs.com):
-
-  ```shell
-  $ npm install -g bower
-  ```
-
-  > If you encounter permission issues when running `npm` see the article about [fixing npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) on npmjs.com
-
-4. Use Bower to install the dependencies of the element:
+2. Use [npm](https://npmjs.com) to install the dependencies of the element:
 
   ```shell
   $ cd vaadin-combo-box
-  $ bower install
+  $ npm install
   ```
 
 ### Running demos


### PR DESCRIPTION
`bower install` is performed automatically in postinstall hook of every component, no need to run it manually, examples:

- https://github.com/vaadin/vaadin-date-picker/blob/master/package.json#L30
- https://github.com/vaadin/vaadin-combo-box/blob/master/package.json#L33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-core-elements/85)
<!-- Reviewable:end -->
